### PR TITLE
ci: install goimports, for make generate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
     <<: *docker_golang
     steps:
       - checkout
+      - run: go install golang.org/x/tools/cmd/goimports
       - run: make generate
       - run: |
           if ! git diff --exit-code --name-only; then

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	go.opencensus.io v0.22.5
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b // indirect
-	golang.org/x/tools v0.0.0-20201229221835-b8413747bbd4 // indirect
+	golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e // indirect
 	google.golang.org/api v0.36.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -809,6 +809,8 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2 h1:vEtypaVub6UvKkiXZ2xx9QI
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201229221835-b8413747bbd4 h1:oy2nvUJn52tUNTQ5hMOyc/N1qDMXpr6gg6GgsKMPMPc=
 golang.org/x/tools v0.0.0-20201229221835-b8413747bbd4/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e h1:Z2uDrs8MyXUWJbwGc4V+nGjV4Ygo+oubBbWSVQw21/I=
+golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=

--- a/tools.go
+++ b/tools.go
@@ -5,4 +5,5 @@ package main
 import (
 	_ "github.com/go-jet/jet/v2/cmd/jet"
 	_ "github.com/onsi/ginkgo/ginkgo"
+	_ "golang.org/x/tools/cmd/goimports"
 )


### PR DESCRIPTION
Otherwise we'll fail to format the code, which breaks CI.