### PR TITLE
Exponentially backoff when import jobs fail

### DIFF
--- a/internal/dbschema/pgsink/model/import_jobs.go
+++ b/internal/dbschema/pgsink/model/import_jobs.go
@@ -23,4 +23,5 @@ type ImportJobs struct {
 	Error          *string
 	Schema         string
 	ErrorCount     int64
+	LastErrorAt    *time.Time
 }

--- a/internal/dbschema/pgsink/table/import_jobs.go
+++ b/internal/dbschema/pgsink/table/import_jobs.go
@@ -28,6 +28,7 @@ type importJobsTable struct {
 	Error          postgres.ColumnString
 	Schema         postgres.ColumnString
 	ErrorCount     postgres.ColumnInteger
+	LastErrorAt    postgres.ColumnTimestampz
 
 	AllColumns     postgres.ColumnList
 	MutableColumns postgres.ColumnList
@@ -66,8 +67,9 @@ func newImportJobsTableImpl(schemaName, tableName string) importJobsTable {
 		ErrorColumn          = postgres.StringColumn("error")
 		SchemaColumn         = postgres.StringColumn("schema")
 		ErrorCountColumn     = postgres.IntegerColumn("error_count")
-		allColumns           = postgres.ColumnList{IDColumn, SubscriptionIDColumn, TableNameColumn, CursorColumn, CompletedAtColumn, ExpiredAtColumn, UpdatedAtColumn, CreatedAtColumn, ErrorColumn, SchemaColumn, ErrorCountColumn}
-		mutableColumns       = postgres.ColumnList{SubscriptionIDColumn, TableNameColumn, CursorColumn, CompletedAtColumn, ExpiredAtColumn, UpdatedAtColumn, CreatedAtColumn, ErrorColumn, SchemaColumn, ErrorCountColumn}
+		LastErrorAtColumn    = postgres.TimestampzColumn("last_error_at")
+		allColumns           = postgres.ColumnList{IDColumn, SubscriptionIDColumn, TableNameColumn, CursorColumn, CompletedAtColumn, ExpiredAtColumn, UpdatedAtColumn, CreatedAtColumn, ErrorColumn, SchemaColumn, ErrorCountColumn, LastErrorAtColumn}
+		mutableColumns       = postgres.ColumnList{SubscriptionIDColumn, TableNameColumn, CursorColumn, CompletedAtColumn, ExpiredAtColumn, UpdatedAtColumn, CreatedAtColumn, ErrorColumn, SchemaColumn, ErrorCountColumn, LastErrorAtColumn}
 	)
 
 	return importJobsTable{
@@ -85,6 +87,7 @@ func newImportJobsTableImpl(schemaName, tableName string) importJobsTable {
 		Error:          ErrorColumn,
 		Schema:         SchemaColumn,
 		ErrorCount:     ErrorCountColumn,
+		LastErrorAt:    LastErrorAtColumn,
 
 		AllColumns:     allColumns,
 		MutableColumns: mutableColumns,

--- a/internal/migration/20210110203230_alter_table_import_jobs_add_error_count.go
+++ b/internal/migration/20210110203230_alter_table_import_jobs_add_error_count.go
@@ -1,0 +1,29 @@
+package migration
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose"
+)
+
+func init() {
+	goose.AddMigration(Up20210110203230, Down20210110203230)
+}
+
+func Up20210110203230(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+	alter table import_jobs
+	add column error_count bigint default 0 not null;
+	`)
+
+	return err
+}
+
+func Down20210110203230(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+	alter table import_jobs
+	drop column error_count;
+	`)
+
+	return err
+}

--- a/internal/migration/20210110210820_alter_table_import_jobs_add_last_error_at.go
+++ b/internal/migration/20210110210820_alter_table_import_jobs_add_last_error_at.go
@@ -1,0 +1,29 @@
+package migration
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose"
+)
+
+func init() {
+	goose.AddMigration(Up20210110210820, Down20210110210820)
+}
+
+func Up20210110210820(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+	alter table import_jobs
+	add column last_error_at timestamptz;
+	`)
+
+	return err
+}
+
+func Down20210110210820(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+	alter table import_jobs
+	drop column last_error_at;
+	`)
+
+	return err
+}

--- a/structure.sql
+++ b/structure.sql
@@ -30,42 +30,6 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
--- Name: goose_db_version; Type: TABLE; Schema: pgsink; Owner: pgsink
---
-
-CREATE TABLE pgsink.goose_db_version (
-    id integer NOT NULL,
-    version_id bigint NOT NULL,
-    is_applied boolean NOT NULL,
-    tstamp timestamp without time zone DEFAULT now()
-);
-
-
-ALTER TABLE pgsink.goose_db_version OWNER TO pgsink;
-
---
--- Name: goose_db_version_id_seq; Type: SEQUENCE; Schema: pgsink; Owner: pgsink
---
-
-CREATE SEQUENCE pgsink.goose_db_version_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-ALTER TABLE pgsink.goose_db_version_id_seq OWNER TO pgsink;
-
---
--- Name: goose_db_version_id_seq; Type: SEQUENCE OWNED BY; Schema: pgsink; Owner: pgsink
---
-
-ALTER SEQUENCE pgsink.goose_db_version_id_seq OWNED BY pgsink.goose_db_version.id;
-
-
---
 -- Name: import_jobs; Type: TABLE; Schema: pgsink; Owner: pgsink
 --
 
@@ -79,7 +43,9 @@ CREATE TABLE pgsink.import_jobs (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     error text,
-    schema text NOT NULL
+    schema text NOT NULL,
+    error_count bigint DEFAULT 0 NOT NULL,
+    last_error_at timestamp with time zone
 );
 
 
@@ -143,13 +109,6 @@ ALTER SEQUENCE pgsink.schema_migrations_id_seq OWNED BY pgsink.schema_migrations
 
 
 --
--- Name: goose_db_version id; Type: DEFAULT; Schema: pgsink; Owner: pgsink
---
-
-ALTER TABLE ONLY pgsink.goose_db_version ALTER COLUMN id SET DEFAULT nextval('pgsink.goose_db_version_id_seq'::regclass);
-
-
---
 -- Name: import_jobs id; Type: DEFAULT; Schema: pgsink; Owner: pgsink
 --
 
@@ -161,14 +120,6 @@ ALTER TABLE ONLY pgsink.import_jobs ALTER COLUMN id SET DEFAULT nextval('pgsink.
 --
 
 ALTER TABLE ONLY pgsink.schema_migrations ALTER COLUMN id SET DEFAULT nextval('pgsink.schema_migrations_id_seq'::regclass);
-
-
---
--- Name: goose_db_version goose_db_version_pkey; Type: CONSTRAINT; Schema: pgsink; Owner: pgsink
---
-
-ALTER TABLE ONLY pgsink.goose_db_version
-    ADD CONSTRAINT goose_db_version_pkey PRIMARY KEY (id);
 
 
 --


### PR DESCRIPTION
Repeating the job over and over with no repeat was a bit aggressive.
This allows us to gradually back-off.

It's implemented with jet expressions, and pushing a lot of work into
the database. This is a bit complicated but not terrible- the
alternative is to calculate the next due at time when a job errors,
which might be nicer. Not least because it materializes that value into
the database, for debugging.