### PR TITLE
Fix error when decoding null types

### DIFF
--- a/pkg/decode/cmd/generate_mappings.go
+++ b/pkg/decode/cmd/generate_mappings.go
@@ -119,7 +119,7 @@ var cfg = Config{
 			Empty: "new(uint32)",
 		},
 		"json": {
-			Empty: "new(interface{})",
+			Empty: "new(string)",
 		},
 		"float4": {
 			Empty: "new(float32)",
@@ -176,7 +176,7 @@ var cfg = Config{
 			Empty: "new([]time.Time)",
 		},
 		"jsonb": {
-			Empty: "new(interface{})",
+			Empty: "new(string)",
 		},
 	},
 }

--- a/pkg/decode/cmd/generate_mappings.go
+++ b/pkg/decode/cmd/generate_mappings.go
@@ -45,6 +45,14 @@ type Config struct {
 	Templates   map[string]TemplatedTypeMapping
 }
 
+func init() {
+	for _, name := range cfg.Unsupported {
+		if _, ok := cfg.Templates[name]; ok {
+			log.Fatalf("type '%s' is both supported and unsupported", name)
+		}
+	}
+}
+
 var cfg = Config{
 	Unsupported: []string{
 		"tid",
@@ -64,7 +72,6 @@ var cfg = Config{
 		"_aclitem",
 		"_inet",
 		"bpchar",
-		"date",
 		"interval",
 		"_numeric",
 		"bit",
@@ -112,7 +119,7 @@ var cfg = Config{
 			Empty: "new(uint32)",
 		},
 		"json": {
-			Empty: "new([]byte)",
+			Empty: "new(interface{})",
 		},
 		"float4": {
 			Empty: "new(float32)",
@@ -127,7 +134,7 @@ var cfg = Config{
 			Empty: "new([]int16)",
 		},
 		"_int4": {
-			Empty: "new([]int64)",
+			Empty: "new([]int32)",
 		},
 		"_text": {
 			Empty: "new([]string)",
@@ -151,7 +158,7 @@ var cfg = Config{
 			Empty: "new(time.Time)",
 		},
 		"time": {
-			Empty: "new(int64)",
+			Empty: "new(time.Time)",
 		},
 		"timestamp": {
 			Empty: "new(time.Time)",
@@ -169,7 +176,7 @@ var cfg = Config{
 			Empty: "new([]time.Time)",
 		},
 		"jsonb": {
-			Empty: "new(string)",
+			Empty: "new(interface{})",
 		},
 	},
 }

--- a/pkg/decode/decode.go
+++ b/pkg/decode/decode.go
@@ -18,6 +18,17 @@ type Decoder interface {
 	ScannerFor(oid uint32) (scanner Scanner, dest interface{}, err error)
 }
 
+// Unpack extracts the value from a scanner destination, should it be present. Otherwise
+// we return nil.
+func Unpack(dest interface{}) interface{} {
+	elem := reflect.ValueOf(dest).Elem()
+	if elem.IsNil() {
+		return nil
+	}
+
+	return elem.Elem().Interface()
+}
+
 // UnregisteredType is returned whenever we see a Postgres OID that has no associated type
 // mapping. How we handle this depends on the caller.
 type UnregisteredType struct {

--- a/pkg/decode/decode.go
+++ b/pkg/decode/decode.go
@@ -69,7 +69,7 @@ func (t TypeMapping) NewScanner() Scanner {
 // It will return a handle to the exact type of Empty. This means something like a string
 // will be given as a *string, likewise with *[]string, etc.
 func (t TypeMapping) NewEmpty() interface{} {
-	return reflect.New(reflect.TypeOf(t.Empty).Elem()).Interface()
+	return reflect.New(reflect.TypeOf(t.Empty)).Interface()
 }
 
 // Scanner defines what pgtypes must support to be included in the decoder. It is used to

--- a/pkg/decode/decode_test.go
+++ b/pkg/decode/decode_test.go
@@ -128,20 +128,22 @@ var _ = Describe("Decoder", func() {
 				match: Equal(uint32(11)),
 			},
 		},
+		// Both JSON types are taken as strings, for now. We might want to parse it properly
+		// in future, but we need support in the sinks to decide how best to handle them.
 		"json": {
 			{
 				value: `'{"It is the east": "and Juliet is the sun"}'`,
-				match: Equal(map[string]interface{}{
-					"It is the east": "and Juliet is the sun",
-				}),
+				match: MatchJSON(`{
+					"It is the east": "and Juliet is the sun"
+				}`),
 			},
 		},
 		"jsonb": {
 			{
 				value: `'{"O happy dagger!": "This is thy sheath"}'`,
-				match: Equal(map[string]interface{}{
-					"O happy dagger!": "This is thy sheath",
-				}),
+				match: MatchJSON(`{
+					"O happy dagger!": "This is thy sheath"
+				}`),
 			},
 		},
 		"float4": {

--- a/pkg/decode/decode_test.go
+++ b/pkg/decode/decode_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 )
 
 var _ = Describe("Decoder", func() {
@@ -37,7 +38,7 @@ var _ = Describe("Decoder", func() {
 
 			Expect(scanner.Scan(raw)).To(Succeed())
 			Expect(scanner.AssignTo(dest)).To(Succeed())
-			Expect(dest).To(BeEquivalentTo(&[]string{"peek", "a", "boo"}))
+			Expect(dest).To(PointTo(PointTo(BeEquivalentTo([]string{"peek", "a", "boo"}))))
 		})
 	})
 })

--- a/pkg/decode/decode_test.go
+++ b/pkg/decode/decode_test.go
@@ -1,15 +1,22 @@
 package decode_test
 
 import (
-	"github.com/jackc/pgtype"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lawrencejones/pgsink/internal/dbtest"
 	"github.com/lawrencejones/pgsink/pkg/decode"
 	"github.com/lawrencejones/pgsink/pkg/decode/gen/mappings"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
+	. "github.com/onsi/gomega/types"
 )
 
+// The aim of these tests is to exercise all the registered type mappings, confirming that
+// we can decode what Postgres gives us into the type of our choosing.
 var _ = Describe("Decoder", func() {
 	var (
 		decoder decode.Decoder
@@ -19,26 +26,394 @@ var _ = Describe("Decoder", func() {
 		decoder = decode.NewDecoder(mappings.Mappings)
 	})
 
-	Context("with array types", func() {
-		// This needs to be replaced with comprehensive tests for each of the Postgres types,
-		// pulling them from the database and asserting that they match the empty values we
-		// expect. For now, it shows how we can use the scanners to achieve parsing.
-		It("can decode into Golang native slices", func() {
-			scanner, dest, err := decoder.ScannerFor(pgtype.TextArrayOID)
-			Expect(err).NotTo(HaveOccurred())
+	mustParseTimestamp := func(val string) time.Time {
+		ts, err := time.Parse(time.RFC3339, val)
+		if err != nil {
+			panic(err.Error())
+		}
 
-			// Use pgtype.TextArray to generate a text encoded array
-			var raw []byte
+		return ts
+	}
+
+	type testCase struct {
+		value string
+		match GomegaMatcher
+	}
+	testCasesByTypeName := map[string][]testCase{
+		"bool": {
 			{
-				arr := new(pgtype.TextArray)
-				arr.Set([]string{"peek", "a", "boo"})
-				raw, err = arr.EncodeText(nil, []byte{})
-				Expect(err).NotTo(HaveOccurred())
+				value: "true",
+				match: Equal(true),
+			},
+			{
+				value: "false",
+				match: Equal(false),
+			},
+		},
+		"bytea": {
+			{
+				value: "decode('DEADBEEF', 'hex')",
+				match: Equal([]byte{0xDE, 0xAD, 0xBE, 0xEF}),
+			},
+		},
+		"name": {
+			{
+				value: "'spartacus'",
+				match: Equal("spartacus"),
+			},
+		},
+		"int8": {
+			{
+				value: "0",
+				match: Equal(int64(0)),
+			},
+			{
+				value: "3",
+				match: Equal(int64(3)),
+			},
+			{
+				value: "-7",
+				match: Equal(int64(-7)),
+			},
+		},
+		"int2": {
+			{
+				value: "0",
+				match: Equal(int16(0)),
+			},
+			{
+				value: "3",
+				match: Equal(int16(3)),
+			},
+			{
+				value: "-7",
+				match: Equal(int16(-7)),
+			},
+		},
+		"int4": {
+			{
+				value: "0",
+				match: Equal(int32(0)),
+			},
+			{
+				value: "3",
+				match: Equal(int32(3)),
+			},
+			{
+				value: "-7",
+				match: Equal(int32(-7)),
+			},
+		},
+		"text": {
+			{
+				value: "'But soft, what light through yonder window breaks?'",
+				match: Equal("But soft, what light through yonder window breaks?"),
+			},
+		},
+		"oid": {
+			{
+				value: "3",
+				match: Equal(uint32(3)),
+			},
+		},
+		"xid": {
+			{
+				value: "'7'::xid",
+				match: Equal(uint32(7)),
+			},
+		},
+		"cid": {
+			{
+				value: "'11'::cid",
+				match: Equal(uint32(11)),
+			},
+		},
+		"json": {
+			{
+				value: `'{"It is the east": "and Juliet is the sun"}'`,
+				match: Equal(map[string]interface{}{
+					"It is the east": "and Juliet is the sun",
+				}),
+			},
+		},
+		"jsonb": {
+			{
+				value: `'{"O happy dagger!": "This is thy sheath"}'`,
+				match: Equal(map[string]interface{}{
+					"O happy dagger!": "This is thy sheath",
+				}),
+			},
+		},
+		"float4": {
+			{
+				value: "0.0",
+				match: Equal(float32(0.0)),
+			},
+			{
+				value: "1.33",
+				match: Equal(float32(1.33)),
+			},
+			{
+				value: "-7.1",
+				match: Equal(float32(-7.1)),
+			},
+		},
+		"float8": {
+			{
+				value: "0.0",
+				match: Equal(float64(0.0)),
+			},
+			{
+				value: "1.33",
+				match: Equal(float64(1.33)),
+			},
+			{
+				value: "-7.1",
+				match: Equal(float64(-7.1)),
+			},
+		},
+		"_bool": {
+			{
+				value: "'{}'",
+				match: Equal([]bool{}),
+			},
+			{
+				value: "'{true}'",
+				match: Equal([]bool{true}),
+			},
+			{
+				value: "'{false}'",
+				match: Equal([]bool{false}),
+			},
+		},
+		"_int2": {
+			{
+				value: "'{}'",
+				match: Equal([]int16{}),
+			},
+			{
+				value: "'{3}'",
+				match: Equal([]int16{3}),
+			},
+			{
+				value: "'{-7}'",
+				match: Equal([]int16{-7}),
+			},
+		},
+		"_int4": {
+			{
+				value: "'{}'",
+				match: Equal([]int32{}),
+			},
+			{
+				value: "'{3}'",
+				match: Equal([]int32{3}),
+			},
+			{
+				value: "'{-7}'",
+				match: Equal([]int32{-7}),
+			},
+		},
+		"_int8": {
+			{
+				value: "'{}'",
+				match: Equal([]int64{}),
+			},
+			{
+				value: "'{3}'",
+				match: Equal([]int64{3}),
+			},
+			{
+				value: "'{-7}'",
+				match: Equal([]int64{-7}),
+			},
+		},
+		"_text": {
+			{
+				value: "'{}'",
+				match: Equal([]string{}),
+			},
+			{
+				value: `'{"I defy you, stars!"}'`,
+				match: Equal([]string{
+					"I defy you, stars!",
+				}),
+			},
+		},
+		"_varchar": {
+			{
+				value: "'{}'",
+				match: Equal([]string{}),
+			},
+			{
+				value: `'{"O me, what fray was here?"}'`,
+				match: Equal([]string{
+					"O me, what fray was here?",
+				}),
+			},
+		},
+		"_float4": {
+			{
+				value: "'{}'",
+				match: Equal([]float32{}),
+			},
+			{
+				value: "'{1.33}'",
+				match: Equal([]float32{1.33}),
+			},
+			{
+				value: "'{-7.9}'",
+				match: Equal([]float32{-7.9}),
+			},
+		},
+		"_float8": {
+			{
+				value: "'{}'",
+				match: Equal([]float64{}),
+			},
+			{
+				value: "'{1.33}'",
+				match: Equal([]float64{1.33}),
+			},
+			{
+				value: "'{-7.9}'",
+				match: Equal([]float64{-7.9}),
+			},
+		},
+		"varchar": {
+			{
+				value: "''",
+				match: Equal(""),
+			},
+			{
+				value: "'It seems she hangs upon the cheek of night'",
+				match: Equal("It seems she hangs upon the cheek of night"),
+			},
+		},
+		"time": {
+			{
+				value: "'04:05:06'::time",
+				// Time types are weird, as they are based on the turn of the mellenia, but are
+				// really an 8 byte microsecond count in PG.
+				match: Equal(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Add(
+					4*time.Hour + 5*time.Minute + 6*time.Second,
+				)),
+			},
+		},
+		"date": {
+			{
+				value: "'2017-01-08'",
+				match: Equal(mustParseTimestamp("2017-01-08T00:00:00Z")),
+			},
+		},
+		"timestamp": {
+			{
+				value: "'2017-01-08 04:05:06'",
+				match: Equal(mustParseTimestamp("2017-01-08T04:05:06Z")),
+			},
+		},
+		"timestamptz": {
+			{
+				value: "'2017-01-08 04:05:06 +01:00'",
+				match: BeTemporally("==", mustParseTimestamp("2017-01-08T04:05:06+01:00")),
+			},
+		},
+		"_timestamptz": {
+			{
+				value: "'{}'",
+				match: Equal([]time.Time{}),
+			},
+			{
+				value: `'{"2017-01-08 04:05:06 +01:00"}'`,
+				match: ConsistOf(
+					BeTemporally("==", mustParseTimestamp("2017-01-08T04:05:06+01:00")),
+				),
+			},
+		},
+		"_timestamp": {
+			{
+				value: "'{}'",
+				match: Equal([]time.Time{}),
+			},
+			{
+				value: `'{"2017-01-08 04:05:06"}'`,
+				match: Equal([]time.Time{
+					mustParseTimestamp("2017-01-08T04:05:06Z"),
+				}),
+			},
+		},
+		"_date": {
+			{
+				value: "'{}'",
+				match: Equal([]time.Time{}),
+			},
+		},
+	}
+	mappings.Each(func(name string, mapping decode.TypeMapping) {
+		Describe(fmt.Sprintf("%s (%v)", name, mapping.OID), func() {
+			var (
+				ctx    context.Context
+				cancel func()
+			)
+
+			var (
+				schema           = "decode_test"
+				tableExampleName = "example"
+				tableExample     = fmt.Sprintf("%s.%s", schema, tableExampleName)
+			)
+
+			db := dbtest.Configure(
+				dbtest.WithSchema(schema),
+				dbtest.WithTable(schema, tableExampleName, fmt.Sprintf("field %s", mapping.Name)),
+			)
+
+			BeforeEach(func() {
+				ctx, cancel = db.Setup(context.Background(), 10*time.Second)
+			})
+
+			AfterEach(func() {
+				cancel()
+			})
+
+			// For every type, we need a test case that validates we can decode a null value
+			// into a Golang nil.
+			entries := []TableEntry{
+				Entry("NULL", "NULL", BeNil()),
+			}
+			for _, testCase := range testCasesByTypeName[mapping.Name] {
+				entries = append(entries, Entry(testCase.value, testCase.value, testCase.match))
 			}
 
-			Expect(scanner.Scan(raw)).To(Succeed())
-			Expect(scanner.AssignTo(dest)).To(Succeed())
-			Expect(dest).To(PointTo(PointTo(BeEquivalentTo([]string{"peek", "a", "boo"}))))
+			// For any types that we don't have non-NULL test cases, create a failing test. This
+			// ensures we have test cases for all of our valid mappings.
+			if _, ok := testCasesByTypeName[mapping.Name]; !ok {
+				It("has non-NULL values", func() {
+					Fail("need to provide non-NULL examples for this type")
+				})
+			}
+
+			DescribeTable("it decodes correct value for",
+				func(value string, match GomegaMatcher) {
+					db.MustExec(ctx, fmt.Sprintf("insert into %s (field) values (%s);", tableExample, value))
+
+					scanner, dest, err := decoder.ScannerFor(mapping.OID)
+					Expect(err).NotTo(HaveOccurred())
+
+					rows, err := db.GetDB().QueryContext(ctx, fmt.Sprintf("select field from %s;", tableExample))
+					Expect(err).NotTo(HaveOccurred())
+
+					for rows.Next() {
+						err := rows.Scan(scanner)
+						Expect(err).NotTo(HaveOccurred())
+
+						err = scanner.AssignTo(dest)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(decode.Unpack(dest)).To(match)
+					}
+				},
+				entries...,
+			)
 		})
 	})
 })

--- a/pkg/decode/gen/mappings/mappings.go
+++ b/pkg/decode/gen/mappings/mappings.go
@@ -81,7 +81,7 @@ var Mappings = []decode.TypeMapping{
 		Name:    "json",
 		OID:     114,
 		Scanner: &pgtype.JSON{},
-		Empty:   new(interface{}),
+		Empty:   new(string),
 	},
 	{
 		Name:    "float4",
@@ -195,7 +195,7 @@ var Mappings = []decode.TypeMapping{
 		Name:    "jsonb",
 		OID:     3802,
 		Scanner: &pgtype.JSONB{},
-		Empty:   new(interface{}),
+		Empty:   new(string),
 	},
 }
 

--- a/pkg/decode/gen/mappings/mappings.go
+++ b/pkg/decode/gen/mappings/mappings.go
@@ -81,7 +81,7 @@ var Mappings = []decode.TypeMapping{
 		Name:    "json",
 		OID:     114,
 		Scanner: &pgtype.JSON{},
-		Empty:   new([]byte),
+		Empty:   new(interface{}),
 	},
 	{
 		Name:    "float4",
@@ -111,7 +111,7 @@ var Mappings = []decode.TypeMapping{
 		Name:    "_int4",
 		OID:     1007,
 		Scanner: &pgtype.Int4Array{},
-		Empty:   new([]int64),
+		Empty:   new([]int32),
 	},
 	{
 		Name:    "_text",
@@ -150,10 +150,16 @@ var Mappings = []decode.TypeMapping{
 		Empty:   new(string),
 	},
 	{
+		Name:    "date",
+		OID:     1082,
+		Scanner: &pgtype.Date{},
+		Empty:   new(time.Time),
+	},
+	{
 		Name:    "time",
 		OID:     1083,
 		Scanner: &pgtype.Time{},
-		Empty:   new(int64),
+		Empty:   new(time.Time),
 	},
 	{
 		Name:    "timestamp",
@@ -189,7 +195,7 @@ var Mappings = []decode.TypeMapping{
 		Name:    "jsonb",
 		OID:     3802,
 		Scanner: &pgtype.JSONB{},
-		Empty:   new(string),
+		Empty:   new(interface{}),
 	},
 }
 
@@ -267,10 +273,6 @@ var Unsupported = []decode.TypeMapping{
 	{
 		Name: "bpchar",
 		OID:  1042,
-	},
-	{
-		Name: "date",
-		OID:  1082,
 	},
 	{
 		Name: "interval",

--- a/pkg/imports/importer.go
+++ b/pkg/imports/importer.go
@@ -219,7 +219,7 @@ forEachRow:
 			}
 
 			// Dereference the value we get from our destination, to remove double pointer-ing
-			row[column.Name] = reflect.ValueOf(dest).Elem().Interface()
+			row[column.Name] = reflect.ValueOf(dest).Elem().Elem().Interface()
 		}
 
 		tableRowsRead.Inc()

--- a/pkg/imports/importer.go
+++ b/pkg/imports/importer.go
@@ -3,7 +3,6 @@ package imports
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/lawrencejones/pgsink/internal/dbschema/pgsink/model"
@@ -219,7 +218,7 @@ forEachRow:
 			}
 
 			// Dereference the value we get from our destination, to remove double pointer-ing
-			row[column.Name] = reflect.ValueOf(dest).Elem().Elem().Interface()
+			row[column.Name] = decode.Unpack(dest)
 		}
 
 		tableRowsRead.Inc()

--- a/pkg/sinks/bigquery/decoder_test.go
+++ b/pkg/sinks/bigquery/decoder_test.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/lawrencejones/pgsink/pkg/decode"
 	"github.com/lawrencejones/pgsink/pkg/decode/gen/mappings"
@@ -17,7 +18,7 @@ import (
 var _ = Describe("fieldTypeFor", func() {
 	mappings.Each(func(name string, mapping decode.TypeMapping) {
 		It(fmt.Sprintf("OID %s (%v) is supported", name, mapping.OID), func() {
-			_, _, err := fieldTypeFor(mapping.NewEmpty())
+			_, _, err := fieldTypeFor(reflect.ValueOf(mapping.NewEmpty()).Elem().Interface())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/subscription/marshal.go
+++ b/pkg/subscription/marshal.go
@@ -39,7 +39,7 @@ func MarshalTuple(decoder decode.Decoder, relation *logical.Relation, tuple []lo
 		}
 
 		// Dereference the value we get from our destination, to remove double pointer-ing
-		row[column.Name] = reflect.ValueOf(dest).Elem().Interface()
+		row[column.Name] = reflect.ValueOf(dest).Elem().Elem().Interface()
 	}
 
 	return row, nil

--- a/pkg/subscription/marshal.go
+++ b/pkg/subscription/marshal.go
@@ -1,8 +1,6 @@
 package subscription
 
 import (
-	"reflect"
-
 	"github.com/lawrencejones/pgsink/pkg/decode"
 	"github.com/lawrencejones/pgsink/pkg/logical"
 )
@@ -39,7 +37,7 @@ func MarshalTuple(decoder decode.Decoder, relation *logical.Relation, tuple []lo
 		}
 
 		// Dereference the value we get from our destination, to remove double pointer-ing
-		row[column.Name] = reflect.ValueOf(dest).Elem().Elem().Interface()
+		row[column.Name] = decode.Unpack(dest)
 	}
 
 	return row, nil


### PR DESCRIPTION
It turns out we need the double pointer for the decoder empty type,
otherwise we'll fail to assign to our target type when the value is
null.

We should test for this specific situation with import and subscription
data.