### PR TITLE
fsync=off for development and test databases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
   docker_postgres: &docker_postgres
     image: postgres:13.1
     command: |
-      docker-entrypoint.sh postgres -c 'wal_level=logical'
+      docker-entrypoint.sh postgres -c 'wal_level=logical' -c 'fsync=off'
     environment:
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       - postgres
       - -c
       - config_file=/etc/postgresql/postgresql.conf
+      # Turn fsync off, so we can run tests faster (not to be used in
+      # production)
+      - -c
+      - fsync=off
     volumes:
       - ./docker/postgres/postgresql.conf:/etc/postgresql/postgresql.conf
       - postgres-data:/var/lib/postgresql


### PR DESCRIPTION
Postgres fsync's around operations like creating and dropping tables.
Turning fsync off allows the tests to run much faster.