### PR TITLE
BigQuery: support table clustering

### DIFF
--- a/pkg/changelog/schema.go
+++ b/pkg/changelog/schema.go
@@ -43,6 +43,17 @@ func SchemaFromRelation(timestamp time.Time, lsn *uint64, relation *logical.Rela
 	}
 }
 
+// GetPrimaryKey generates a tuple of keys included in the primary key of the table.
+func (s Schema) GetPrimaryKey() (keys []string) {
+	for _, column := range s.Spec.Columns {
+		if column.Key {
+			keys = append(keys, column.Name)
+		}
+	}
+
+	return
+}
+
 // GetFingerprint returns a unique idenfier for the schema.
 //
 // The only important thing is that any given schema returns the same fingerprint for the

--- a/pkg/sinks/bigquery/decoder.go
+++ b/pkg/sinks/bigquery/decoder.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	bq "cloud.google.com/go/bigquery"
@@ -9,7 +10,12 @@ import (
 
 // fieldTypeFor maps Postgres OID types to BigQuery types, allowing us to build BigQuery
 // schemas from Postgres type information.
-func fieldTypeFor(val interface{}) (fieldType bq.FieldType, repeated bool, err error) {
+func fieldTypeFor(empty interface{}) (fieldType bq.FieldType, repeated bool, err error) {
+	// We receive an empty paramter, generated from a mapping.NewEmpty, or the destination
+	// of a scanner. We want to unpack that to get the typed pointer, as the empty value
+	// will be double pointed.
+	val := reflect.ValueOf(empty).Elem().Interface()
+
 	switch val.(type) {
 	case *bool:
 		return bq.BooleanFieldType, repeated, nil

--- a/pkg/sinks/bigquery/decoder_test.go
+++ b/pkg/sinks/bigquery/decoder_test.go
@@ -2,7 +2,6 @@ package bigquery
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/lawrencejones/pgsink/pkg/decode"
 	"github.com/lawrencejones/pgsink/pkg/decode/gen/mappings"
@@ -18,7 +17,7 @@ import (
 var _ = Describe("fieldTypeFor", func() {
 	mappings.Each(func(name string, mapping decode.TypeMapping) {
 		It(fmt.Sprintf("OID %s (%v) is supported", name, mapping.OID), func() {
-			_, _, err := fieldTypeFor(reflect.ValueOf(mapping.NewEmpty()).Elem().Interface())
+			_, _, err := fieldTypeFor(mapping.NewEmpty())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/sinks/bigquery/schema_builders_test.go
+++ b/pkg/sinks/bigquery/schema_builders_test.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/jackc/pgtype"
 	"github.com/lawrencejones/pgsink/pkg/changelog"
+	"github.com/lawrencejones/pgsink/pkg/decode"
+	"github.com/lawrencejones/pgsink/pkg/decode/gen/mappings"
 	"github.com/lawrencejones/pgsink/pkg/logical"
+
 	. "github.com/onsi/ginkgo"
 	_ "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -61,6 +64,30 @@ var (
 		},
 	}
 )
+
+var _ = Describe("buildRaw", func() {
+	var (
+		md            *bq.TableMetadata
+		err           error
+		schemaFixture *changelog.Schema
+	)
+
+	JustBeforeEach(func() {
+		md, err = buildRaw("example", schemaFixture, decode.NewDecoder(mappings.Mappings))
+	})
+
+	BeforeEach(func() {
+		schemaFixture = &dogsSchemaFixture
+	})
+
+	It("does not error", func() {
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("clusters the table by primary key", func() {
+		Expect(md.Clustering.Fields).To(Equal([]string{"tag"}))
+	})
+})
 
 var _ = Describe("buildView", func() {
 	var (


### PR DESCRIPTION
Support clustering the raw tables by the Postgres primary key, which
should make queries a lot more efficient.

While here, fix a clear bug in the typing of the mapping. I'd been
relying on the tests to verify this, but they weren't complete. Clear
evidence we need an integration test!