### PR TITLE
127.0.0.1 for testing

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -23,7 +23,7 @@ import (
 func Start(ctx context.Context, binaryArgs []string) *Harness {
 	var serveAddress string
 	{
-		listener, err := net.Listen("tcp", ":0")
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
 		Expect(err).NotTo(HaveOccurred())
 		listener.Close()
 		serveAddress = fmt.Sprintf(


### PR DESCRIPTION
I wondered why localhost wasn't working, and only realised I hadn't
closed the listener when fixing the tests in CI.

On Darwin, something about hitting the firewall when binding to the port
meant we'd recover from the error and the test would succeed. Not ideal
really, this is much healthier (and avoids the annoying firewall warning
on each test).